### PR TITLE
Add observability stack with Grafana, Loki, and Tempo

### DIFF
--- a/backend/Makefile
+++ b/backend/Makefile
@@ -8,7 +8,31 @@ all: gen build test
 
 run: gen
 	@echo -e ":: $(GREEN)Starting backend...$(NC)"
-	@go run cmd/backend/main.go
+	@DEBUG=true go run cmd/backend/main.go
+
+observe: gen
+	@echo -e ":: $(GREEN)Starting observability stack...$(NC)"
+	@docker compose -f observe/docker-compose.yml up --quiet-pull -d \
+		&& echo -e "  -> Observability stack started" \
+		|| (echo -e "  -> $(RED)Failed to start observability stack$(NC)" && exit 1)
+
+	$(call wait_healthy,observe-loki-1)
+
+	@echo -e ":: $(GREEN)Streaming logs to Vector (local binary) with OTEL enabled...$(NC)"
+	@echo -e "  -> If start successfully, you can open http://localhost:3000/explore?schemaVersion=1&panes=%7B%2251t%22%3A%7B%22datasource%22%3A%22P8E80F9AEF21F6940%22%2C%22queries%22%3A%5B%7B%22refId%22%3A%22A%22%2C%22expr%22%3A%22%7Bapp%3D%5C%22cli-forum-dev%5C%22%7D+%7C+json+%7C+line_format+%5C%22%5B%7B%7B+.level+%7D%7D%5D+%7B%7B+.msg+%7D%7D+%28%7B%7B+.caller+%7D%7D%29%5C%22%22%2C%22queryType%22%3A%22range%22%2C%22datasource%22%3A%7B%22type%22%3A%22loki%22%2C%22uid%22%3A%22P8E80F9AEF21F6940%22%7D%2C%22editorMode%22%3A%22code%22%2C%22direction%22%3A%22backward%22%7D%5D%2C%22range%22%3A%7B%22from%22%3A%22now-24h%22%2C%22to%22%3A%22now%22%7D%2C%22panelsState%22%3A%7B%22logs%22%3A%7B%22visualisationType%22%3A%22logs%22%7D%7D%7D%7D&orgId=1 to see the logs"
+	@DEBUG=false go run cmd/backend/main.go \
+		| vector --config ./observe/vector.toml \
+		&& echo -e "==> $(BLUE)Observe mode completed$(NC)" && make stop-observe \
+		|| (echo -e "==> $(RED)Observe mode failed$(NC)" && make stop-observe && exit 1)
+
+start-observe:
+	@echo -e ":: $(GREEN)Starting observability stack...$(NC)"
+	@docker compose -f observe/docker-compose.yml up --quiet-pull -d \
+		&& echo -e "  -> Observability stack started" \
+		|| (echo -e "  -> $(RED)Failed to start observability stack$(NC)" && exit 1)
+
+stop-observe:
+	$(call stop-observe)
 
 build: gen
 	@echo -e ":: $(GREEN)Building backend...$(NC)"
@@ -28,3 +52,18 @@ gen:
 test: gen
 	@echo -e ":: $(GREEN)Running tests...$(NC)"
 	@go test -cover ./... && echo -e "==> $(BLUE)All tests passed$(NC)" || echo -e "==> $(RED)Tests failed$(NC)"
+
+define wait_healthy
+	@echo -e ":: $(GREEN)Waiting for $1 container to become healthy...$(NC)"
+	@echo -e "  -> This may take a while..."
+	@timeout 60 bash -c 'until [ "$$(docker inspect --format="{{.State.Health.Status}}" $1 2>/dev/null)" = "healthy" ]; do sleep 1; done' \
+		&& echo -e "  -> $1 is healthy" \
+		|| (echo -e "  -> $(RED)$1 did not become healthy in time$(NC)" && exit 1)
+endef
+
+define stop-observe
+	@echo -e ":: $(GREEN)Stopping observability stack...$(NC)"
+	@docker compose -f observe/docker-compose.yml down \
+		&& echo -e "  -> Observability stack stopped" \
+		|| (echo -e "  -> $(RED)Failed to stop observability stack$(NC)" && exit 1)
+endef

--- a/backend/internal/comment/handler_test.go
+++ b/backend/internal/comment/handler_test.go
@@ -54,7 +54,7 @@ func TestHandler_CreateHandler(t *testing.T) {
 				AuthorId:  "7942c917-4770-43c1-a56a-952186b9970e",
 				Title:     "Test Title",
 				Content:   "Test Content",
-				CreatedAt: time.Date(2023, 10, 1, 0, 0, 0, 0, time.UTC).String(),
+				CreatedAt: "2023-10-01T00:00:00Z",
 			},
 		},
 		{

--- a/backend/internal/comment/models.go
+++ b/backend/internal/comment/models.go
@@ -18,6 +18,14 @@ type Comment struct {
 	CreatedAt pgtype.Timestamptz
 }
 
+type Post struct {
+	ID       uuid.UUID
+	AuthorID uuid.UUID
+	Title    pgtype.Text
+	Content  pgtype.Text
+	CreateAt pgtype.Timestamptz
+}
+
 type User struct {
 	ID       uuid.UUID
 	Name     string

--- a/backend/internal/logger.go
+++ b/backend/internal/logger.go
@@ -16,8 +16,8 @@ func ZapProductionConfig() zap.Config {
 		DisableStacktrace: true,
 		Encoding:          "json",
 		EncoderConfig:     zap.NewProductionEncoderConfig(),
-		OutputPaths:       []string{"stderr"},
-		ErrorOutputPaths:  []string{"stderr"},
+		OutputPaths:       []string{"stdout"},
+		ErrorOutputPaths:  []string{"stdout"},
 	}
 }
 

--- a/backend/internal/post/models.go
+++ b/backend/internal/post/models.go
@@ -9,6 +9,15 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
+type Comment struct {
+	ID        uuid.UUID
+	PostID    uuid.UUID
+	AuthorID  uuid.UUID
+	Title     pgtype.Text
+	Content   pgtype.Text
+	CreatedAt pgtype.Timestamptz
+}
+
 type Post struct {
 	ID       uuid.UUID
 	AuthorID uuid.UUID

--- a/backend/observe/docker-compose.yml
+++ b/backend/observe/docker-compose.yml
@@ -1,0 +1,62 @@
+services:
+  grafana:
+    image: grafana/grafana:latest
+    ports:
+      - "3000:3000"
+    environment:
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
+    depends_on:
+      - loki
+      - tempo
+    healthcheck:
+      test: [ "CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost:3000/api/health || exit 1" ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - observe-net
+    entrypoint:
+      - sh
+      - -euc
+      - |
+        mkdir -p /etc/grafana/provisioning/datasources
+        cat <<EOF > /etc/grafana/provisioning/datasources/ds.yaml
+        apiVersion: 1
+        datasources:
+          - name: Loki
+            type: loki
+            url: http://loki:3100
+          - name: Tempo
+            type: tempo
+            url: http://tempo:3200
+        EOF
+        /run.sh
+
+  loki:
+    image: grafana/loki:latest
+    command: -config.file=/etc/loki/local-config.yaml
+    ports:
+      - "3100:3100"
+    healthcheck:
+      test: [ "CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost:3100/ready || exit 1" ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - observe-net
+
+  tempo:
+    image: grafana/tempo:latest
+    command: ["--config.file=/etc/tempo.yaml"]
+    ports:
+      - "4317:4317"     # gRPC for OTLP
+      - "4318:4318"     # OTLP HTTP receiver
+      - "3200:3200"     # Tempo internal HTTP server (for Grafana)
+    volumes:
+      - ./tempo.yaml:/etc/tempo.yaml
+    networks:
+      - observe-net
+
+networks:
+  observe-net:

--- a/backend/observe/tempo.yaml
+++ b/backend/observe/tempo.yaml
@@ -1,0 +1,25 @@
+server:
+  http_listen_port: 3200
+
+distributor:
+  receivers:
+    otlp:
+      protocols:
+        grpc:
+          endpoint: "0.0.0.0:4317"
+
+ingester:
+  trace_idle_period: 10s
+  max_block_duration: 5m
+
+compactor:
+  compaction:
+    block_retention: 1h
+
+storage:
+  trace:
+    backend: local
+    local:
+      path: /tmp/tempo/traces
+    wal:
+      path: /tmp/tempo/wal

--- a/backend/observe/vector.toml
+++ b/backend/observe/vector.toml
@@ -1,0 +1,16 @@
+# vector.toml
+[sources.stdin]
+type = "stdin"
+decoding.codec = "json"
+
+[sinks.to_loki]
+type = "loki"
+inputs = ["stdin"]
+encoding.codec = "json"
+endpoint = "http://localhost:3100"
+labels = { level = "{{ level }}", app = "{{ app_name }}", version = "{{ version }}" }
+
+[sinks.to_console]
+type = "console"
+inputs = ["stdin"]
+encoding.codec = "json"


### PR DESCRIPTION
# Type of change 
- Feature

# Purpose
This pull request introduces observability features to the backend.

# Addition
1. Makefile enhancements:
- Added observe target to enable the observability stack, including starting Docker containers for observability services such as Grafana, Loki, and Tempo.
- Added start-observe and stop-observe commands for managing the observability stack.
- Defined wait_healthy and stop-observe functions for better handling of Docker container health and teardown processes.

2. New Docker Compose file:
- Added backend/observe/docker-compose.yml to configure observability services:
  - Grafana: Provides dashboards and visualizations for logs and metrics.
  - Loki: Handles log aggregation and querying.
  - Tempo: Manages distributed tracing.

3. Vector configuration:
- Added backend/observe/vector.toml for configuring log streaming to Loki.

These changes enable developers to monitor application logs and metrics effectively, improving debugging and observability in the development environment.

